### PR TITLE
Fix small typo in help-gitHubApiUrl.html

### DIFF
--- a/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/help-gitHubApiUrl.html
+++ b/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/help-gitHubApiUrl.html
@@ -3,6 +3,6 @@
 
     <p></p>
 
-    For repositories on <code>http://www.github.com</code> leaf this field empty.
+    For repositories on <code>http://www.github.com</code> leave this field empty.
     For your dedicated instance of GitHub put in format: <code>http(s)://hostname/api/v3/</code>
 </div>


### PR DESCRIPTION
Super trivial change to fix a typo in the tooltip documentation: leaf -> leave
